### PR TITLE
fix config file name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ FlipFlop.configure do |config|
 end
 ```
 
-and add a YAML file: `config/flip-flop.yml`
+and add a YAML file: `config/flip_flop.yml`
 
 for example:
 


### PR DESCRIPTION
The config file was referenced previously in the file as `flip_flop.yml` and not `flip-flop.yml`
